### PR TITLE
Add testing tooling

### DIFF
--- a/models/spacy/Spacy.py
+++ b/models/spacy/Spacy.py
@@ -71,9 +71,9 @@ class SpacyModel:
 		document = spacy_nlp(corpus)
 
 		# Print Token and Tag of the document_page
-		for token in document:
-			print(token.text, token.lemma_, token.pos_, token.tag_, token.dep_,
-				  token.shape_, token.is_alpha, token.is_stop)
+		# for token in document:
+		#	print(token.text, token.lemma_, token.pos_, token.tag_, token.dep_,
+		#		  token.shape_, token.is_alpha, token.is_stop)
 
 		matcher.add("FECHAS", None, *self._get_patterns())
 		matches = matcher(document)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ catalogue==1.0.0
 certifi==2019.11.28
 chardet==3.0.4
 cymem==2.0.3
-es-core-news-sm==2.2.5
+https://github.com/explosion/spacy-models/releases/download/es_core_news_sm-2.2.5/es_core_news_sm-2.2.5.tar.gz
 idna==2.9
 murmurhash==1.0.2
 nltk==3.4.5

--- a/test/ConfusionMatrix.py
+++ b/test/ConfusionMatrix.py
@@ -1,0 +1,19 @@
+class ConfusionMatrix:
+
+    def __init__(self, corpus, results, expected):
+        self.corpus = corpus
+        self.results = results
+        self.expected = expected
+        self.FP = [item for item in self.results if item not in self.expected]
+        self.FN = [item for item in self.expected if item not in self.results]
+        self.TP = len(self.expected)
+        self.precision = self.TP / (self.TP + len(self.FP))
+        self.recall = self.TP / (self.TP + len(self.FN))
+        self.F1 = 2 * self.TP / (2 * self.TP + len(self.FP) + len(self.FN))
+
+    def print(self):
+        print("FP({}): {}".format(len(self.FP), self.FP))
+        print("FN({}): {}".format(len(self.FN), self.FN))
+        print("Precision = {}".format(self.precision))
+        print("Recall = {}".format(self.recall))
+        print("F1 = {}\n".format(self.F1))

--- a/test/test_ej_2_es.py
+++ b/test/test_ej_2_es.py
@@ -1,0 +1,98 @@
+import unittest
+import spacy
+import timeit
+
+from models.spacy.Spacy import SpacyModel
+from test.ConfusionMatrix import ConfusionMatrix
+
+
+class TestEj2Es(unittest.TestCase):
+    corpus = ""
+    expected = ['31/05/2017-151:161',
+                '31 de mayo de 2017-446:464',
+                '6 de abril de 2016-689:707',
+                '28 de enero de 2016-1052:1071',
+                '28 de enero de 2016-1851:1870',
+                '19.12.2015-2148:2158',
+                '16 de enero de 2016-2525:2544',
+                '6 de abril de 2016-4198:4216',
+                '28/01/16-4625:4633',
+                '21 de junio de 2016-7077:7096',
+                '21 de noviembre de 2016-7377:7400',
+                '9 de junio de 2016-7578:7596',
+                '23 de junio de 2016-7669:7688',
+                '14 de diciembre de 2016-7734:7757',
+                '4 de abril de 2017-7853:7871',
+                '25 de abril de 2017-7977:7996',
+                '28 de enero de 2016-8436:8455',
+                '19 de diciembre de 2015-8919:8942',
+                '6 de abril de 2016-10201:10219',
+                '5 de octubre-11456:11468',
+                '30 de marzo-17041:17052',
+                '23 de mayo-22597:22607',
+                '11 de abril-29021:29032',
+                '29 de abril-29049:29060',
+                '1 de abril-29077:29087',
+                '30 de marzo-29104:29115',
+                '11 de mayo-29132:29142',
+                '24 de mayo-29161:29171',
+                '5 de octubre-31141:31153',
+                '18 de noviembre-33493:33508',
+                '26 de octubre de 2010-33775:33796',
+                '26 de octubre de 2010-35400:35421',
+                '10 de septiembre-35993:36009',
+                '14 de noviembre-37432:37447',
+                '6 de abril de 2016-42854:42872']
+
+    @classmethod
+    def setUpClass(cls):
+        f = open("documents/ej_2_es_cleaned.txt", encoding="utf8")
+        cls.corpus = f.read()
+        f.close()
+
+    def test_es_core_legal_sm(self):
+        t1 = timeit.default_timer()
+        spacy_nlp = spacy.load('models/custom_model/es_core_legal_sm')
+        spacy_nlp.max_length = 2000000
+        t2 = timeit.default_timer()
+
+        print("\nModel es_core_legal_sm")
+        print(f"Time to load : {t2 - t1}")
+
+        ents = spacy_nlp(self.corpus).ents
+        results = [f"{ent.text}-{ent.start_char}:{ent.end_char}" for ent in ents if ent.label_ == 'FECHA']
+
+        cm = ConfusionMatrix(self.corpus, results, self.expected)
+        cm.print()
+        self.assertGreater(cm.F1, 0.9)
+
+    def test_blank_model(self):
+        t1 = timeit.default_timer()
+        spacy_nlp = spacy.load('models/custom_model/blank_model')
+        spacy_nlp.max_length = 2000000
+        t2 = timeit.default_timer()
+
+        print("\nModel blank_model")
+        print(f"Time to load : {t2 - t1}")
+
+        ents = spacy_nlp(self.corpus).ents
+        results = [f"{ent.text}-{ent.start_char}:{ent.end_char}" for ent in ents if ent.label_ == 'FECHA']
+
+        cm = ConfusionMatrix(self.corpus, results, self.expected)
+        cm.print()
+        self.assertGreater(cm.F1, 0.9)
+
+    def test_spacy(self):
+        t1 = timeit.default_timer()
+        spacy_model = SpacyModel()
+        results = spacy_model.execute_core_algorithm(self.corpus)
+        t2 = timeit.default_timer()
+
+        print("\nSpacy")
+        print(f"Time to load : {t2 - t1}")
+
+        results = [f"{span.text}-{span.start_char}:{span.end_char}" for span in results]
+
+        cm = ConfusionMatrix(self.corpus, results, self.expected)
+        cm.print()
+        self.assertGreater(cm.F1, 0.9)


### PR DESCRIPTION
Added sample test case for ej_2_es input including utility class to compute confusion matrix metrics.

Run all tests:
`python -m unittest`

Run all test for ej_2_es:
`python -m unittest test.test_ej_2_es.TestEj2Es`

Run test for es_core_legal_sm on ej_2_es:
`python -m unittest test.test_ej_2_es.TestEj2Es.test_es_core_legal_sm`